### PR TITLE
Find out if all the time slots for the entire week are blank

### DIFF
--- a/src/data/FieldData.php
+++ b/src/data/FieldData.php
@@ -71,7 +71,9 @@ class FieldData extends \ArrayObject
     public function getIsAllBlank(): bool
     {
         foreach ($this as $day) {
-            if (!$day->getIsBlank()) { return false; }
+            if (!$day->getIsBlank()) {
+                return false;
+            }
         }
 
         return true;

--- a/src/data/FieldData.php
+++ b/src/data/FieldData.php
@@ -62,4 +62,18 @@ class FieldData extends \ArrayObject
             array_slice($data, 0, $end + 1)
         );
     }
+    
+    /**
+     * Returns whether any day has any time slots filled in.
+     *
+     * @return bool
+     */
+    public function getIsAllBlank(): bool
+    {
+        foreach ($this as $day) {
+            if (!$day->getIsBlank()) { return false; }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
It’s now possible to find out if all the time slots for all days are blank via `entry.<FieldHandle>.getIsAllBlank().