### PR TITLE
The install/plugin command is deprecated, using plugin/install instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd /path/to/my-project.test
 composer require craftcms/store-hours
 
 # tell Craft to install the plugin
-./craft install/plugin store-hours
+./craft plugin/install store-hours
 ```
 
 ## Customizing Time Slots


### PR DESCRIPTION
### Description
Just a simple update in the readme using the correct install command.


### Related issues

