### PR TITLE
GraphQL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Store Hours
 
+## Unreleased
+
+- Added GraphQL support. ([#55](https://github.com/craftcms/store-hours/pull/55))
+- Added `craft\storehours\gql\types\Day`.
+- Added `craft\storehours\gql\types\generators\DayType`.
+
 ## 3.0.0 - 2022-05-03
 
 ### Added

--- a/src/gql/types/Day.php
+++ b/src/gql/types/Day.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\storehours\gql\types;
+
+use craft\gql\base\ObjectType;
+use craft\gql\types\DateTime;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Class Day
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.1.0
+ */
+class Day extends ObjectType
+{
+    /**
+     * @inheritdoc
+     */
+    protected function resolve(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): mixed
+    {
+        return $source[$resolveInfo->fieldName];
+    }
+
+    /**
+     * Returns day fields prepared for GraphQL object definition.
+     *
+     * @param array $slots
+     * @return array
+     */
+    public static function prepareFieldDefinition(array $slots): array
+    {
+        $contentFields = [];
+        foreach ($slots as $slotId => $slot) {
+            $handle = ($slot['handle'] ?? false) ?: $slotId;
+            $contentFields[$handle] = DateTime::getType();
+        }
+        return $contentFields;
+    }
+}

--- a/src/gql/types/generators/DayType.php
+++ b/src/gql/types/generators/DayType.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\storehours\gql\types\generators;
+
+use Craft;
+use craft\gql\base\GeneratorInterface;
+use craft\gql\base\ObjectType;
+use craft\gql\base\SingleGeneratorInterface;
+use craft\gql\GqlEntityRegistry;
+use craft\storehours\Field;
+use craft\storehours\gql\types\Day;
+
+/**
+ * Class DayType
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.1.0
+ */
+class DayType implements GeneratorInterface, SingleGeneratorInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public static function generateTypes(mixed $context = null): array
+    {
+        return [static::generateType($context)];
+    }
+
+    /**
+     * Returns the generator name.
+     *
+     * @return string
+     */
+    public static function getName($context = null): string
+    {
+        /** @var Field $context */
+        return "{$context->handle}_Day";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function generateType(mixed $context): ObjectType
+    {
+        $typeName = self::getName($context);
+
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new Day([
+            'name' => $typeName,
+            'fields' => function() use ($context, $typeName) {
+                /** @var Field $context */
+                $contentFields = Day::prepareFieldDefinition($context->slots);
+                return Craft::$app->getGql()->prepareFieldDefinitions($contentFields, $typeName);
+            },
+        ]));
+    }
+}


### PR DESCRIPTION
### Description

Adds GraphQL query and mutation support for Store Hours fields.

Store Hours field values are lists of `fieldHandle_Day` types, which contain properties for each of the custom time slots (e.g. `open` and `close`). Mutations can set Store Hours fields to lists of `fieldHandle_DayInput` types, also with time slot-based properties.

### Related issues

- #36
- #34